### PR TITLE
docs(repo): add README, contributing guide, changelog, and GitHub tem…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Reportar erro, comportamento inesperado ou falha funcional
+title: "[BUG] "
+labels: ["type:bug"]
+assignees: []
+---
+
+## Resumo
+
+Descreva o problema de forma **objetiva**.
+
+## Comportamento atual
+
+O que está acontecendo?
+
+## Comportamento esperado
+
+O que **deveria** acontecer?
+
+## Passos para reproduzir
+
+1. 
+2. 
+3. 
+
+## Evidências
+
+Inclua **logs**, **prints**, **payloads** ou qualquer evidência útil.
+
+## Ambiente
+
+- **Branch**:
+- **Sistema operacional**:
+- **Versão Java**:
+- **Observações adicionais**:
+
+## Critérios de aceite
+
+- [ ] **causa** identificada
+- [ ] **correção** implementada
+- [ ] **testes** ajustados/adicionados quando aplicável
+- [ ] **documentação** atualizada se necessário
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Propor nova **funcionalidade** ou **melhoria**
+title: "[FEATURE] "
+labels: ["type:feature"]
+assignees: []
+---
+
+## Objetivo
+
+Descreva o **objetivo** da funcionalidade.
+
+## Contexto
+
+Qual problema isso resolve? Por que essa funcionalidade é **necessária**?
+
+## Escopo
+
+Liste o que deve entrar nesta entrega.
+
+- 
+- 
+- 
+
+## Fora de escopo
+
+Liste o que **não** deve entrar nesta entrega.
+
+- 
+- 
+
+## Critérios de aceite
+
+- [ ]
+- [ ]
+- [ ]
+
+## Observações técnicas
+
+Inclua **restrições**, **dependências** ou decisões já conhecidas.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+Descreva **brevemente** o que este **PR** entrega.
+
+## Related issue
+
+`Closes #`
+
+## Changes made
+
+- 
+- 
+- 
+
+## How to test
+
+1. 
+2. 
+3. 
+
+## Checklist
+
+- [ ] **issue** vinculada
+- [ ] **branch** segue o padrão do projeto
+- [ ] **escopo** está controlado
+- [ ] **testes** aplicáveis executados
+- [ ] **documentação** atualizada quando necessário
+- [ ] sem alterações acidentais ou fora do **escopo**
+
+## Risks / observations
+
+Liste **riscos**, **limitações** ou pontos de atenção.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+Todas as **mudanças relevantes** deste projeto serão documentadas aqui.
+
+Este projeto segue, como referência:
+
+- **[Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/)**
+- **[Semantic Versioning](https://semver.org/lang/pt-BR/)**
+
+## [Unreleased]
+
+### Added
+- estrutura inicial de **documentação** do repositório
+- **README** principal em **pt-BR**
+- **README** resumido em inglês (**README.en.md**)
+- guia de **contribuição** (**CONTRIBUTING.md**)
+- templates iniciais de **issue** e **pull request**
+
+### Changed
+- formatação completa dos arquivos de documentação (**README.md**, **README.en.md**, **CONTRIBUTING.md**)
+
+## [0.1.0] - TBD
+
+### Added
+- **release inicial** do projeto
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,117 @@
+# Contribuindo
+
+Obrigado por dedicar tempo para contribuir com este projeto.
+
+Mesmo sendo um projeto de portfólio com execução principal individual, este repositório segue práticas próximas de um time real de engenharia para reforçar organização, rastreabilidade e disciplina de desenvolvimento.
+
+## Fluxo de trabalho
+
+Toda mudança relevante deve seguir este fluxo:
+
+1. Criar ou identificar uma **issue**
+2. Refinar objetivo e critérios de aceite
+3. Criar uma **branch** a partir de `develop`
+4. Implementar a mudança com escopo controlado
+5. Abrir **Pull Request** para `develop`
+6. Revisar checklist de qualidade
+7. Fazer **merge**
+8. Atualizar documentação quando necessário
+
+## Branches
+
+### Branches principais
+
+- `main`: branch estável
+- `develop`: branch de integração
+
+### Branches de trabalho
+
+Use sempre o identificador da **issue** no nome da branch.
+
+**Padrões:**
+- `feat/{issue-id}-{slug}`
+- `fix/{issue-id}-{slug}`
+- `chore/{issue-id}-{slug}`
+- `docs/{issue-id}-{slug}`
+- `test/{issue-id}-{slug}`
+- `refactor/{issue-id}-{slug}`
+
+**Exemplos:**
+- `feat/12-register-endpoint`
+- `fix/18-invalid-refresh-token`
+- `docs/2-repository-documentation`
+
+## Commits
+
+Este projeto utiliza **[Conventional Commits](https://www.conventionalcommits.org/)**.
+
+**Exemplos:**
+- `feat(auth): implement register endpoint`
+- `fix(security): reject expired refresh token`
+- `docs(readme): improve setup section`
+- `test(auth): add login use case tests`
+
+## Pull Requests
+
+Todo **Pull Request** deve:
+
+- ter escopo pequeno e objetivo
+- estar vinculado a uma **issue**
+- explicar claramente o que foi alterado
+- informar como validar
+- atualizar documentação quando necessário
+- preferencialmente fechar a **issue** com `Closes #ID`
+
+## Checklist antes de abrir PR
+
+- [ ] existe **issue** relacionada
+- [ ] **branch** segue o padrão do projeto
+- [ ] código está consistente com a arquitetura
+- [ ] não introduz complexidade desnecessária
+- [ ] testes aplicáveis foram adicionados/ajustados
+- [ ] documentação foi atualizada quando necessário
+- [ ] **build** local executa com sucesso
+
+## Padrões de qualidade
+
+Ao contribuir, priorize:
+
+- clareza
+- nomes consistentes
+- separação de responsabilidades
+- simplicidade
+- testabilidade
+- **segurança por padrão**
+
+**Evite:**
+- overengineering
+- classes genéricas demais
+- lógica de negócio espalhada em **controller**
+- acoplamento desnecessário
+- alterações grandes sem justificativa
+
+## Issues
+
+As **issues** devem conter, sempre que possível:
+
+- objetivo
+- escopo
+- critérios de aceite
+- impacto esperado
+- área do sistema
+- prioridade
+
+## Documentação
+
+Atualize a documentação quando a mudança afetar:
+
+- **setup**
+- arquitetura
+- comportamento da **API**
+- variáveis de ambiente
+- fluxo de autenticação/autorização
+
+## Código de conduta
+
+Ao interagir neste repositório, mantenha comunicação **respeitosa, clara e profissional**.
+

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,227 @@
+# auth-access-service
+
+Authentication and authorization backend service built with **Java 21** and **Spring Boot 3**, focused on clean architecture, security, testing, and professional engineering practices.
+
+## Overview
+
+`auth-access-service` is a portfolio project designed with a real-world engineering mindset.  
+Its goal is to demonstrate the ability to build a production-style backend service with:
+
+- secure authentication
+- role-based authorization (RBAC)
+- token lifecycle management
+- audit trail
+- API documentation
+- automated tests
+- professional repository and Git workflow organization
+
+This project is meant to showcase backend skills valued by enterprise teams, financial institutions, internal platforms, and systems that require security and traceability.
+
+## Project goals
+
+- Implement user registration and login
+- Issue JWT access token and refresh token
+- Protect routes with Spring Security
+- Control access by role
+- Register authentication-sensitive events
+- Keep API contracts clear and testable
+- Structure the repository with professional standards
+
+## MVP scope
+
+- User registration
+- Login
+- JWT access token
+- Refresh token
+- Logout/revocation
+- RBAC with initial roles (`USER`, `ADMIN`)
+- Protected endpoints
+- Basic audit trail
+- OpenAPI/Swagger
+- Unit and integration tests
+- Docker Compose for local environment
+- CI with GitHub Actions
+
+## Tech stack
+
+- Java 21
+- Spring Boot 3
+- Spring Security
+- Spring Data JPA
+- PostgreSQL
+- Redis
+- Testcontainers
+- JUnit 5
+- Mockito
+- Docker
+- OpenAPI / Swagger
+- GitHub Actions
+
+## Architecture
+
+The project follows a **modular monolith with pragmatic clean architecture**, prioritizing clarity, separation of concerns, and testability without overengineering.
+
+### Layers
+
+- `domain`  
+  Core business rules, entities, and contracts
+
+- `application`  
+  Use cases, orchestration, and application rules
+
+- `infrastructure`  
+  Persistence, security, integrations, and technical implementations
+
+- `interfaces/http`  
+  Controllers, DTOs, input validation, and HTTP concerns
+
+## Planned structure
+
+```text
+src/main/java/com/lucasgomes/authaccessservice
+├── domain
+├── application
+├── infrastructure
+└── interfaces
+    └── http
+```
+
+### Technical decisions
+
+#### JWT + Refresh Token
+
+The project will use short-lived access tokens and persisted/revocable refresh tokens to model a realistic authentication flow.
+
+#### Simple and evolvable RBAC
+
+The initial authorization model will be role-based in order to keep the MVP simple while allowing future evolution.
+
+#### PostgreSQL + Redis
+
+PostgreSQL will be the primary persistence layer.  
+Redis will support token/session-related flows and expiration control as the project evolves.
+
+#### Testing from the beginning
+
+The project will include practical unit and integration test coverage, using Testcontainers for relevant scenarios.
+
+## Roadmap
+
+### M1 Foundation
+- initial project structure
+- documentation
+- local setup
+- Docker Compose
+- base configuration
+- OpenAPI
+- initial pipeline
+
+### M2 Authentication Core
+- registration
+- login
+- JWT
+- refresh token
+- validations
+- password hashing
+
+### M3 Authorization and Security
+- RBAC
+- protected routes
+- access rules
+- logout/revocation
+- basic hardening
+
+### M4 Production Readiness
+- audit trail
+- robust integration tests
+- documentation improvements
+- observability refinements
+- final project release
+
+## Running locally
+
+*In progress. Detailed setup instructions will be updated as the technical foundation is implemented.*
+
+### Expected prerequisites
+- Java 21
+- Docker and Docker Compose
+- Git
+
+### General steps
+1. Clone the repository
+2. Start local dependencies with Docker Compose
+3. Configure environment variables
+4. Run the Spring Boot application
+
+### Environment variables
+
+An example file will be added soon:
+
+`.env.example`
+
+### API documentation
+
+The API documentation will be available through Swagger/OpenAPI after the initial setup is complete.
+
+**Expected path:**
+
+- `/swagger-ui/index.html`
+
+### Quality and testing
+
+The project aims to maintain:
+
+- unit tests for services and rules
+- integration tests for critical flows
+- reproducible build
+- commit and PR conventions
+- minimum documentation per milestone
+
+### Development workflow
+
+- `main` → stable branch
+- `develop` → integration branch
+- work branches by issue:
+  - `feat/{issue-id}-{slug}`
+  - `fix/{issue-id}-{slug}`
+  - `chore/{issue-id}-{slug}`
+  - `docs/{issue-id}-{slug}`
+
+### Conventions
+
+#### Commits
+
+This repository uses [Conventional Commits](https://www.conventionalcommits.org).
+
+**Examples:**
+- `feat(auth): implement login endpoint`
+- `fix(security): validate expired refresh token`
+- `docs(readme): improve architecture overview`
+
+#### Pull Requests
+- small PRs
+- clear scope
+- linked to an issue
+- with validation checklist
+- preferably targeting `develop`
+
+## Contributing
+
+See the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## Changelog
+
+See the [CHANGELOG.md](CHANGELOG.md) file.
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+## Contact
+
+**Lucas Gomes de Oliveira**
+
+- LinkedIn: *add link*
+- GitHub: *add link*
+- Email: lucasgomescomp@hotmail.com
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,227 @@
 # auth-access-service
-Production-style authentication and authorization backend service built with Java 21 and Spring Boot 3.
+
+Serviço backend de autenticação e autorização construído com **Java 21** e **Spring Boot 3**, com foco em arquitetura limpa, segurança, testes e boas práticas de engenharia.
+
+## Visão geral
+
+O `auth-access-service` é um projeto de portfólio com abordagem próxima de um ambiente real de engenharia.  
+O objetivo é demonstrar capacidade de construir um backend corporativo com:
+
+- autenticação segura
+- autorização baseada em papéis (RBAC)
+- ciclo de vida de tokens
+- trilha de auditoria
+- documentação de API
+- testes automatizados
+- organização de repositório e fluxo Git profissional
+
+Este projeto foi desenhado para reforçar competências valorizadas em times backend que trabalham com sistemas internos, produtos corporativos, instituições financeiras e ambientes com requisitos de segurança e rastreabilidade.
+
+## Objetivos do projeto
+
+- Implementar registro e login de usuários
+- Emitir access token JWT e refresh token
+- Proteger rotas com Spring Security
+- Controlar acesso por role
+- Registrar eventos sensíveis de autenticação
+- Manter contratos de API claros e testáveis
+- Estruturar o repositório com padrão profissional
+
+## Escopo do MVP
+
+- Cadastro de usuário
+- Login
+- JWT access token
+- Refresh token
+- Logout/revogação
+- RBAC com papéis iniciais (`USER`, `ADMIN`)
+- Endpoints protegidos
+- Auditoria básica
+- OpenAPI/Swagger
+- Testes unitários e de integração
+- Docker Compose para ambiente local
+- CI com GitHub Actions
+
+## Stack
+
+- Java 21
+- Spring Boot 3
+- Spring Security
+- Spring Data JPA
+- PostgreSQL
+- Redis
+- Testcontainers
+- JUnit 5
+- Mockito
+- Docker
+- OpenAPI / Swagger
+- GitHub Actions
+
+## Arquitetura
+
+O projeto segue uma abordagem de **modular monolith com clean architecture pragmática**, priorizando clareza, separação de responsabilidades e testabilidade sem overengineering.
+
+### Camadas
+
+- **`domain`**  
+  Regras centrais de negócio, entidades e contratos
+
+- **`application`**  
+  Casos de uso, orquestração e regras de aplicação
+
+- **`infrastructure`**  
+  Persistência, segurança, integrações e implementações técnicas
+
+- **`interfaces/http`**  
+  Controllers, DTOs, validações de entrada e tratamento HTTP
+
+## Estrutura planejada
+
+```text
+src/main/java/com/lucasgomes/authaccessservice
+├── domain
+├── application
+├── infrastructure
+└── interfaces
+    └── http
+```
+
+### Principais decisões técnicas
+
+#### JWT + Refresh Token
+
+O projeto utilizará access token de curta duração e refresh token com controle de persistência/revogação para representar um fluxo realista de autenticação.
+
+#### RBAC simples e evolutivo
+
+A autorização inicial será baseada em roles para manter simplicidade no MVP e permitir evolução futura sem complicar o design prematuramente.
+
+#### PostgreSQL + Redis
+
+O PostgreSQL será usado como fonte principal de persistência.  
+O Redis será utilizado para apoiar fluxos de token, sessão e controle de expiração conforme a evolução do projeto.
+
+#### Testes desde a base
+
+O projeto será construído com cobertura prática de testes unitários e de integração, com uso de Testcontainers para cenários relevantes.
+
+## Roadmap
+
+### M1 Foundation
+- estrutura inicial do projeto
+- documentação
+- setup local
+- Docker Compose
+- configuração base
+- OpenAPI
+- pipeline inicial
+
+### M2 Authentication Core
+- registro
+- login
+- JWT
+- refresh token
+- validações
+- hashing de senha
+
+### M3 Authorization and Security
+- RBAC
+- rotas protegidas
+- regras de acesso
+- logout/revogação
+- hardening básico
+
+### M4 Production Readiness
+- auditoria
+- testes de integração robustos
+- melhoria de documentação
+- ajustes finais de observabilidade
+- release final do projeto
+
+## Como rodar localmente
+
+*Em construção. O setup detalhado será atualizado conforme a base técnica do projeto for implementada.*
+
+### Pré-requisitos esperados
+- Java 21
+- Docker e Docker Compose
+- Git
+
+### Passos gerais
+1. Clonar o repositório
+2. Subir dependências locais com Docker Compose
+3. Configurar variáveis de ambiente
+4. Executar a aplicação Spring Boot
+
+### Variáveis de ambiente
+
+Um arquivo de exemplo será adicionado em breve:
+
+`.env.example`
+
+### Documentação da API
+
+A documentação da API será disponibilizada via Swagger/OpenAPI após a configuração inicial do projeto.
+
+Exemplo esperado:
+
+- `/swagger-ui/index.html`
+
+### Qualidade e testes
+
+O projeto buscará manter:
+
+- testes unitários para regras e serviços
+- testes de integração para fluxos críticos
+- build reproduzível
+- convenções de commit e PR
+- documentação mínima por milestone
+
+### Fluxo de desenvolvimento
+
+- `main` → branch estável
+- `develop` → branch de integração
+- branches de trabalho por issue:
+  - `feat/{issue-id}-{slug}`
+  - `fix/{issue-id}-{slug}`
+  - `chore/{issue-id}-{slug}`
+  - `docs/{issue-id}-{slug}`
+
+### Convenções
+
+#### Commits
+
+Este repositório usa [Conventional Commits](https://www.conventionalcommits.org).
+
+**Exemplos:**
+- `feat(auth): implement login endpoint`
+- `fix(security): validate expired refresh token`
+- `docs(readme): improve architecture overview`
+
+#### Pull Requests
+- PRs pequenos
+- escopo claro
+- vinculados a issue
+- com checklist de validação
+- preferencialmente para `develop`
+
+## Contribuição
+
+Veja o arquivo [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Changelog
+
+Veja o arquivo [CHANGELOG.md](CHANGELOG.md).
+
+## Licença
+
+Este projeto está sob a [licença MIT](LICENSE).
+
+## Contato
+
+**Lucas Gomes de Oliveira**
+
+- LinkedIn: *adicionar link*
+- GitHub: *adicionar link*
+- Email: lucasgomescomp@hotmail.com
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO List for README.md Formatting
+
+## Plan Steps:
+1. [x] Create TODO.md 
+2. [x] Reformat README.md section after '## Estrutura planejada' using create_file with precise Markdown headings, lists, and spacing matching earlier sections style.
+3. [x] Update TODO.md to mark step 2 complete.
+4. [x] Verify formatting and attempt_completion.
+


### PR DESCRIPTION
## Summary
Add initial repository documentation and GitHub templates to establish a professional project structure.

## Changes
- added README.md (pt-BR)
- added README.en.md
- added CONTRIBUTING.md
- added CHANGELOG.md
- added issue templates (bug, feature)
- added pull request template
- organized .github folder

## Why
This aligns the repository with professional engineering standards and prepares the project for structured development.

## How to test
- verify README renders correctly
- verify issue templates are available when creating new issues
- verify PR template appears when opening a pull request

Closes #2