### PR TITLE
feat(api): add health check endpoint

### DIFF
--- a/src/main/java/com/lucasgomes/auth_access_service/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/lucasgomes/auth_access_service/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.lucasgomes.auth_access_service.infrastructure.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/health").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/lucasgomes/auth_access_service/interfaces/http/HealthController.java
+++ b/src/main/java/com/lucasgomes/auth_access_service/interfaces/http/HealthController.java
@@ -1,0 +1,18 @@
+package com.lucasgomes.auth_access_service.interfaces.http;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of(
+                "status", "UP",
+                "service", "auth-access-service"
+        );
+    }
+}

--- a/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
+++ b/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
@@ -1,1 +1,3 @@
+com\lucasgomes\auth_access_service\interfaces\http\HealthController.class
 com\lucasgomes\auth_access_service\AuthAccessServiceApplication.class
+com\lucasgomes\auth_access_service\infrastructure\security\SecurityConfig.class

--- a/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,1 +1,3 @@
 C:\Users\lucas\OneDrive\Documentos\014 - PORTIFOLIO\auth-access-service\src\main\java\com\lucasgomes\auth_access_service\AuthAccessServiceApplication.java
+C:\Users\lucas\OneDrive\Documentos\014 - PORTIFOLIO\auth-access-service\src\main\java\com\lucasgomes\auth_access_service\infrastructure\security\SecurityConfig.java
+C:\Users\lucas\OneDrive\Documentos\014 - PORTIFOLIO\auth-access-service\src\main\java\com\lucasgomes\auth_access_service\interfaces\http\HealthController.java


### PR DESCRIPTION
## Summary
Add a health check endpoint to validate API availability.

## Related issue
Closes #5

## Changes made
- added HealthController
- implemented GET /health endpoint
- configured security to allow public access to /health

## How to test
1. Run the application
2. Access http://localhost:8080/health
3. Confirm JSON response

## Notes
Security is partially configured to allow public access only to the health endpoint.